### PR TITLE
fix: restrict project secrets and clarify dashboard state

### DIFF
--- a/src/app/api/projects/[id]/credentials/route.ts
+++ b/src/app/api/projects/[id]/credentials/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+import { getCurrentAdmin } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { ProjectService } from '@/lib/services/project.service';
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  const admin = await getCurrentAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  await ProjectService.verifyProjectAccess(id, admin.sub);
+  const credentials = await db.project.findUnique({
+    where: { id },
+    select: {
+      botToken: true,
+      maxBotToken: true,
+      webhookSecret: true
+    }
+  });
+  if (!credentials) {
+    return NextResponse.json({ error: 'Проект не найден' }, { status: 404 });
+  }
+
+  return NextResponse.json(credentials, {
+    headers: { 'Cache-Control': 'private, no-store' }
+  });
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -112,8 +112,17 @@ export async function GET(
     }
 
     // Возвращаем проект с подсчетом пользователей и bonusMode
+    const {
+      botToken: _botToken,
+      maxBotToken: _maxBotToken,
+      webhookSecret: _webhookSecret,
+      ...safeProject
+    } = project;
     const response = {
-      ...project,
+      ...safeProject,
+      botConfigured: Boolean(_botToken),
+      maxBotConfigured: Boolean(_maxBotToken),
+      webhookConfigured: Boolean(_webhookSecret),
       ...(bonusModeValue !== undefined && { bonusMode: bonusModeValue }),
       _count: {
         users: userCount

--- a/src/app/dashboard/bonuses/components/bonus-management-client.tsx
+++ b/src/app/dashboard/bonuses/components/bonus-management-client.tsx
@@ -62,7 +62,6 @@ export function BonusManagementClient({
     users,
     isLoading: usersLoading,
     totalUsers,
-    totalBonuses,
     currentPage,
     totalCount,
     loadUsers,
@@ -73,17 +72,12 @@ export function BonusManagementClient({
     searchTerm: ''
   });
 
-  // Stats data. activeBonuses/expiringSoon приходят из initialData.stats —
-  // это реальные агрегаты по всем проектам владельца (посчитаны на сервере
-  // при загрузке страницы), а не по выбранному в селекторе проекту, поэтому
-  // они не всегда будут 1:1 совпадать с totalUsers/totalBonuses ниже (те
-  // живые и относятся к текущему selectedProjectId). Это лучше, чем
-  // показывать выдуманное число, но точный расчёт по выбранному проекту
-  // потребует отдельного API-запроса.
+  // Все KPI в этом блоке имеют один scope: весь аккаунт владельца.
+  // Селектор ниже фильтрует таблицу, но не меняет смысл верхних карточек.
   const statsData = {
-    totalProjects: initialData.projects.length,
-    totalUsers,
-    totalBonuses,
+    totalProjects: initialData.stats.totalProjects,
+    totalUsers: initialData.stats.totalUsers,
+    totalBonuses: initialData.stats.totalBonuses,
     activeBonuses: initialData.stats.activeBonuses,
     expiringSoon: initialData.stats.expiringSoon
   };

--- a/src/app/dashboard/bonuses/loading.tsx
+++ b/src/app/dashboard/bonuses/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function BonusesLoading() {
+  return (
+    <div className='space-y-6 p-6' aria-label='Загрузка бонусов'>
+      <Skeleton className='h-10 w-72 max-w-full' />
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className='h-28 rounded-xl' />
+        ))}
+      </div>
+      <Skeleton className='h-[28rem]' />
+    </div>
+  );
+}

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DashboardLoading() {
+  return (
+    <div className='space-y-6 px-6 py-6' aria-label='Загрузка дашборда'>
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-5'>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <Skeleton key={index} className='h-28 rounded-xl' />
+        ))}
+      </div>
+      <div className='grid gap-6 lg:grid-cols-7'>
+        <Skeleton className='h-80 lg:col-span-4' />
+        <Skeleton className='h-80 lg:col-span-3' />
+      </div>
+      <Skeleton className='h-56' />
+    </div>
+  );
+}

--- a/src/features/bots/components/bot-management-view-simplified.tsx
+++ b/src/features/bots/components/bot-management-view-simplified.tsx
@@ -78,13 +78,20 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
       setLoading(true);
 
       // Загружаем проект
-      const projectResponse = await fetch(`/api/projects/${projectId}`);
+      const [projectResponse, botResponse] = await Promise.all([
+        fetch(`/api/projects/${projectId}`),
+        fetch(`/api/projects/${projectId}/bot`)
+      ]);
       if (projectResponse.ok) {
-        const projectData = await projectResponse.json();
-        setProject(projectData);
+        const [projectData, botData] = await Promise.all([
+          projectResponse.json(),
+          botResponse.ok ? botResponse.json() : {}
+        ]);
+        const mergedProject = { ...projectData, ...botData };
+        setProject(mergedProject);
         setTokenForm({
-          botToken: projectData.botToken || '',
-          botUsername: projectData.botUsername || ''
+          botToken: mergedProject.botToken || '',
+          botUsername: mergedProject.botUsername || ''
         });
       }
 
@@ -161,10 +168,10 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
 
   const handleToggleBot = async () => {
     const isActive = botStatus?.status === 'ACTIVE';
-    
+
     try {
       setToggling(true);
-      
+
       if (isActive) {
         // Останавливаем бота
         const response = await fetch(`/api/projects/${projectId}/bot/restart`, {
@@ -206,7 +213,7 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
           });
         }
       }
-      
+
       await checkBotStatus();
     } catch (error) {
       toast({
@@ -252,11 +259,11 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
               <CardTitle>Подключение бота</CardTitle>
               <CardDescription>
                 Получите токен у{' '}
-                <a 
-                  href="https://t.me/botfather" 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="text-primary underline hover:text-primary/80"
+                <a
+                  href='https://t.me/botfather'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary hover:text-primary/80 underline'
                 >
                   @BotFather
                 </a>{' '}
@@ -320,7 +327,7 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
                     }
                     setEditingToken(true);
                   }}
-                  title="Редактировать токен"
+                  title='Редактировать токен'
                 >
                   <Edit className='h-4 w-4' />
                 </Button>
@@ -331,7 +338,7 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
                   onClick={() => setEditingToken(true)}
                   disabled={saving}
                 >
-                  <Edit className='h-4 w-4 mr-2' />
+                  <Edit className='mr-2 h-4 w-4' />
                   Добавить токен
                 </Button>
               )}
@@ -412,7 +419,8 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
             <Alert>
               <Bot className='h-4 w-4' />
               <AlertDescription>
-                <strong>@{botStatus.bot.username}</strong> • {botStatus.bot.firstName}
+                <strong>@{botStatus.bot.username}</strong> •{' '}
+                {botStatus.bot.firstName}
               </AlertDescription>
             </Alert>
           )}
@@ -424,17 +432,15 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
         <Card>
           <CardHeader>
             <CardTitle>Управление ботом</CardTitle>
-            <CardDescription>
-              Запустите или остановите бота
-            </CardDescription>
+            <CardDescription>Запустите или остановите бота</CardDescription>
           </CardHeader>
           <CardContent className='space-y-4'>
             <div className='flex items-center justify-between'>
               <div>
                 <p className='text-sm font-medium'>Статус бота</p>
                 <p className='text-muted-foreground text-sm'>
-                  {isActive 
-                    ? 'Бот запущен и обрабатывает сообщения' 
+                  {isActive
+                    ? 'Бот запущен и обрабатывает сообщения'
                     : 'Бот остановлен'}
                 </p>
               </div>
@@ -469,13 +475,16 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
           <Alert className='mb-4'>
             <Workflow className='h-4 w-4' />
             <AlertDescription>
-              Все сообщения, команды и действия бота настраиваются через конструктор workflow.
-              Это позволяет гибко управлять поведением бота без конфликтов.
+              Все сообщения, команды и действия бота настраиваются через
+              конструктор workflow. Это позволяет гибко управлять поведением
+              бота без конфликтов.
             </AlertDescription>
           </Alert>
-          
+
           <Button
-            onClick={() => router.push(`/dashboard/projects/${projectId}/workflow`)}
+            onClick={() =>
+              router.push(`/dashboard/projects/${projectId}/workflow`)
+            }
             size='lg'
             className='w-full'
           >
@@ -487,4 +496,3 @@ export function BotManagementView({ projectId }: BotManagementViewProps) {
     </div>
   );
 }
-

--- a/src/features/projects/components/project-settings-view.tsx
+++ b/src/features/projects/components/project-settings-view.tsx
@@ -113,12 +113,17 @@ export function ProjectSettingsView({
       setLoading(true);
 
       // Загружаем проект, уровни и статистику параллельно
-      const [projectResponse, levelsResponse, statsResponse] =
-        await Promise.all([
-          fetch(`/api/projects/${projectId}`),
-          fetch(`/api/projects/${projectId}/bonus-levels`),
-          fetch(`/api/projects/${projectId}/stats`)
-        ]);
+      const [
+        projectResponse,
+        credentialsResponse,
+        levelsResponse,
+        statsResponse
+      ] = await Promise.all([
+        fetch(`/api/projects/${projectId}`),
+        fetch(`/api/projects/${projectId}/credentials`),
+        fetch(`/api/projects/${projectId}/bonus-levels`),
+        fetch(`/api/projects/${projectId}/stats`)
+      ]);
 
       // Проверяем наличие уровней
       if (levelsResponse.ok) {
@@ -140,7 +145,11 @@ export function ProjectSettingsView({
       }
 
       if (projectResponse.ok) {
-        const projectData = await projectResponse.json();
+        const [projectData, credentials] = await Promise.all([
+          projectResponse.json(),
+          credentialsResponse.ok ? credentialsResponse.json() : {}
+        ]);
+        Object.assign(projectData, credentials);
         setLoadError(null);
         setProject(projectData);
         setFormData({

--- a/src/features/projects/components/tilda-integration-view.tsx
+++ b/src/features/projects/components/tilda-integration-view.tsx
@@ -238,11 +238,19 @@ export function ProjectIntegrationView({
 
   async function loadProject() {
     try {
-      const response = await fetch(`/api/projects/${projectId}`);
-      if (!response.ok) throw new Error('Failed to load project');
+      const [response, credentialsResponse] = await Promise.all([
+        fetch(`/api/projects/${projectId}`),
+        fetch(`/api/projects/${projectId}/credentials`)
+      ]);
+      if (!response.ok || !credentialsResponse.ok) {
+        throw new Error('Failed to load project');
+      }
 
-      const data = await response.json();
-      setProject(data);
+      const [data, credentials] = await Promise.all([
+        response.json(),
+        credentialsResponse.json()
+      ]);
+      setProject({ ...data, ...credentials });
 
       // Загружаем настройки виджета из нового endpoint /widget
       try {

--- a/src/lib/services/partner-team.service.ts
+++ b/src/lib/services/partner-team.service.ts
@@ -27,8 +27,6 @@ function legacyPartnerRoleLevel(role: PartnerRole): number | null {
 export type TeamMemberRow = {
   id: string;
   name: string;
-  email: string | null;
-  phone: string | null;
   partnerRole: string;
   organizationLevel: number | null;
   organizationTitle: string | null;
@@ -449,8 +447,6 @@ export class PartnerTeamService {
       items.push({
         id: p.id,
         name: displayName(p),
-        email: p.email,
-        phone: p.phone,
         partnerRole: p.partnerRole,
         organizationLevel: membership?.level ?? null,
         organizationTitle: membership?.title ?? null,


### PR DESCRIPTION
Follow-up to the B2B audit remediation.\n\n- keep bot and webhook secrets out of the generic project API\n- expose credentials only through the owner-protected settings endpoint\n- remove partner-facing email and phone fields\n- correct account-wide bonus KPIs\n- add real dashboard loading states\n\nValidation: production build, focused ESLint, and 20 focused tests passed.